### PR TITLE
Two years later, change the API endpoint :p

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,7 +1,5 @@
 import axios from 'axios'
 
 export const axiosInstance = axios.create({
-  baseURL: 'https://api.sep.osoc.be'
+  baseURL: 'https://solidelections.elections-osoc.s.redhost.be'
 })
-
-


### PR DESCRIPTION
Soooooooooooo

ABB wants to demo this application, but our old API hosting has been taken down. I've set it up on a new server, but that means we need to change the API endpoint in the frontend :)